### PR TITLE
기능 추가 : User Entity 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'

--- a/src/main/java/com/lolpee/server/core/constant/AuthConstant.java
+++ b/src/main/java/com/lolpee/server/core/constant/AuthConstant.java
@@ -1,0 +1,5 @@
+package com.lolpee.server.core.constant;
+
+public class AuthConstant {
+    public static final String ROLE_PREFIX = "ROLE_";
+}

--- a/src/main/java/com/lolpee/server/domain/user/dto/AuthData.java
+++ b/src/main/java/com/lolpee/server/domain/user/dto/AuthData.java
@@ -1,0 +1,8 @@
+package com.lolpee.server.domain.user.dto;
+
+import lombok.Builder;
+
+// SignUp
+// SignIn
+public class AuthData {
+}

--- a/src/main/java/com/lolpee/server/domain/user/entity/AuthType.java
+++ b/src/main/java/com/lolpee/server/domain/user/entity/AuthType.java
@@ -1,0 +1,8 @@
+package com.lolpee.server.domain.user.entity;
+
+public enum AuthType {
+    LOCAL,
+    GITHUB,
+    KAKAO,
+    GOOGLE
+}

--- a/src/main/java/com/lolpee/server/domain/user/entity/RoleType.java
+++ b/src/main/java/com/lolpee/server/domain/user/entity/RoleType.java
@@ -1,0 +1,6 @@
+package com.lolpee.server.domain.user.entity;
+
+public enum RoleType {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/lolpee/server/domain/user/entity/User.java
+++ b/src/main/java/com/lolpee/server/domain/user/entity/User.java
@@ -1,0 +1,80 @@
+package com.lolpee.server.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+import static com.lolpee.server.core.constant.AuthConstant.ROLE_PREFIX;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "unique_users_username", columnNames = {"username"}),
+                @UniqueConstraint(name = "unique_users_email", columnNames = {"email"})
+        }
+)
+public class User implements UserDetails {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private AuthType authType;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("USER")
+    private RoleType roleType = RoleType.USER;
+
+    @ColumnDefault("false")
+    private boolean isEmailVerified = false;
+
+    @ColumnDefault("false")
+    private boolean isLocked = false;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(ROLE_PREFIX + roleType.toString()));
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return !this.isLocked;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return this.isEmailVerified && !this.isLocked;
+    }
+}


### PR DESCRIPTION
# Summary    
<br>  

## 기능 추가
- `User`
- `AuthType`
- `RoleType`  
<br>

## 반영 브랜치
- `dev/yongsoo` -> `develop`
<br>

## 작업내용
- `User` : ERD를 기반하여 User 엔티티를 클래스로 구현했습니다.
![UserEntity](https://github.com/SSAFY-11th/lolpee/assets/43926186/01d4c0f7-e6e1-4b1a-9a2c-68be3321d8fc)
- `AuthType`: User의 인증 방식을 구현하기 위해서 Enum 클래스로 구현했습니다.
- `RoleType`: User의 역할을 구현하기 위해서 Enum 클래스로 구현했습니다.
- `AuthConstant`: 인증과 관련된 상수들을 static으로 선언해주어 구현했습니다.
<br>

## PR Point
- 각 클래스 ERD에 맞게 제대로 구성 되었는지 확인 부탁 드립니다.  
<br>
